### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/DateTime/Format/LikeGo.pm6
+++ b/lib/DateTime/Format/LikeGo.pm6
@@ -1,6 +1,6 @@
 use DateTime::Format;
 
-module DateTime::Format::LikeGo;
+unit module DateTime::Format::LikeGo;
 
 # Change whitespace to _, per go's time spec
 my $reference-date = DateTime.new('2006-01-02T15:04:05-0700');


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.
